### PR TITLE
Simplify the installation line

### DIFF
--- a/fedy-installer
+++ b/fedy-installer
@@ -19,8 +19,5 @@ echo "Installing fedy..."
 
 dnf -y --nogpgcheck install fedy
 
-# Remove install script
-rm fedy-installer
-
 # Please report bugs at <http://github.com/folkswithhats/fedy/issues>
 # End of the Script

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
                     <p>To install Fedy in Fedora, open a Terminal and run the following command:</p>
 
                     <div class="code">
-                        <code>bash -c 'su -c "curl <a href="http://folkswithhats.org/fedy-installer">http://folkswithhats.org/fedy-installer</a> -o fedy-installer && chmod +x fedy-installer && ./fedy-installer"'</code>
+                        <code>curl <a href="http://folkswithhats.org/fedy-installer">http://folkswithhats.org/fedy-installer</a> | sudo bash</code>
                     </div>
 
                     <div class="social">


### PR DESCRIPTION
- Why save and `chmod` the file if we can just pipe it to `sudo bash`?
- This also changes `su -c` to `sudo`, since I believe that setups that support `sudo` (i.e. the user is in sudoers) are more common than those that support bare `su` (i.e. the root password is set). Since the command is nice & short now, it would be trivial for the user to replace `sudo` with `su -c` for themselves if they want to.
- It seems like the page itself hasn't been updated with new stuff from this repo recently, can this be fixed?
- It's a bad bad idea to ask users to `curl http://... | sudo bash` (with or without saving the file). Getting HTTPS ASAP is a good idea.
